### PR TITLE
Update TOS to accommodate outbound faxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ fighthealthinsurance/static/js/dist
 # Ignore external storage
 external_storage
 external_data
+.DS_Store

--- a/fighthealthinsurance/templates/tos.html
+++ b/fighthealthinsurance/templates/tos.html
@@ -36,7 +36,7 @@ Terms of Service
     When you use the Services, you understand and agree:
     <ul>
     <li>When you send or submit any information via electronic fax via the Services, you warrant that you have provided true, current, accurate, and complete fax number information.</li>
-    <li>The transmission of unsolicited fax advertisements is illegal under the Federal Telephone Consumer Protection Act of 1991 and a number of similar state laws. Distribution of unsolicited fax advertisements through the Services is prohibited. Accordingly, we intend to use legally available means to prevent distribution of unsolicited fax advertisements to or by recipeints. At our option and without further notice, we may use technologies and procedures, such as filters, that may terminate such unsolicited fax advertisements without delivering them.</li>
+    <li>The transmission of unsolicited fax advertisements is illegal under the Federal Telephone Consumer Protection Act of 1991 and a number of similar state laws. Distribution of unsolicited fax advertisements through the Services is prohibited. Accordingly, we intend to use legally available means to prevent distribution of unsolicited fax advertisements via our Services. At our option and without further notice, we may use technologies and procedures, such as filters, that may terminate such unsolicited fax advertisements without delivering them.</li>
     <li>We accept no responsibility for you being unable to correctly deliver outbound faxes due to any incompatibility, fault or incorrect configuration of our hardware, software or communication services.</li>
     </ul>
       </p>

--- a/fighthealthinsurance/templates/tos.html
+++ b/fighthealthinsurance/templates/tos.html
@@ -16,11 +16,11 @@ Terms of Service
 	These terms of use are entered into by and between you and Totally Legit Co. ("we", “our”, or "us"). The following terms and conditions ("Terms of Use"), govern your access to and use of www.fighthealthinsurance.com (the "Website"), including any functionality or services offered on or through the Website (together with the Website, referred to as the “Services”).
       </p>
       <p>
-	Please read the Terms of Use carefully before you use the Services. BY USING THE SERVICES, YOU ACCEPT AND AGREE TO BE BOUND AND ABIDE BY THESE TERMS OF USE AND OUR <a href="{% absolute_url 'privacy_policy' %}">PRIVACY POLICY</a>, FOUND AT {% absolute_url 'privacy_policy' %}, incorporated herein by reference. If you do not want to agree to these Terms of Use or the <a href="{% absolute_url 'privacy_policy' %}">Privacy Policy</a>, you must not access or use the Services. 
+	Please read the Terms of Use carefully before you use the Services. BY USING THE SERVICES, YOU ACCEPT AND AGREE TO BE BOUND AND ABIDE BY THESE TERMS OF USE AND OUR <a href="{% absolute_url 'privacy_policy' %}">PRIVACY POLICY</a>, FOUND AT {% absolute_url 'privacy_policy' %}, incorporated herein by reference. If you do not want to agree to these Terms of Use or the <a href="{% absolute_url 'privacy_policy' %}">Privacy Policy</a>, you must not access or use the Services.
       </p>
       <h4>What We Do and Limitations of the Services</h4>
       <p>
-	We advocate for holding health insurance companies accountable for improper denials of health insurance claims by providing a tool for generating a template for an appeal to a health insurance claim denial for use by individuals in the United States.   
+	We advocate for holding health insurance companies accountable for improper denials of health insurance claims by providing a tool for generating a template for an appeal to a health insurance claim denial for use by individuals in the United States.
       </p>
       <p>
 	Template appeals and other outputs provided by the Services are created by using machine learning technologies that analyze and use the information you submit to us. When you use the Services, we collect the information that is included in your inputs, file uploads, or other feedback that you provide to the Services. We also use the information you submit through the Services to train large language models that are used in providing the Services. The Services are not intended to collect your medical, healthcare, or insurance information. As such, <b>it is your responsibility to remove all personal information (including your medical, healthcare and insurance information) prior to submitting any information to us.  IF YOU SUBMIT TO THE SERVICES ANY PERSONAL INFORMATION, INCLUDING MEDICAL, HEALTHCARE,  AND INSURANCE INFORMATION, YOU HEREBY CONSENT TO OUR COLLECTION AND USE OF SUCH INFORMATION CONSISTENT WITH OUR <a href="{% absolute_url 'privacy_policy' %}">PRIVACY POLICY</a>.</b> If you have mistakenly submitted such information to us or want to delete it, you may use our deletion page at {% absolute_url 'remove_data' %} to delete the information or contact us at <a href="mailto:support42@fighthealthinsurance.com">support42@fighthealthinsurance.com</a> to request deletion of such information. 
@@ -31,13 +31,22 @@ Terms of Service
       <p>
 	The Services are intended for users who are 18 years of age or older. By using the Services, you represent and warrant that you are of legal age to form a binding contract with the Company and meet all of the foregoing eligibility requirements. If you do not meet all of these requirements, you must not access or use the Services.
       </p>
+      <h4>Customer Responsibilities</h4>
+      <p>
+    When you use the Services, you understand and agree:
+    <ul>
+    <li>When you send or submit any information via electronic fax via the Services, you warrant that you have provided true, current, accurate, and complete fax number information.</li>
+    <li>The transmission of unsolicited fax advertisements is illegal under the Federal Telephone Consumer Protection Act of 1991 and a number of similar state laws. Distribution of unsolicited fax advertisements through the Services is prohibited. Accordingly, we intend to use legally available means to prevent distribution of unsolicited fax advertisements to or by recipeints. At our option and without further notice, we may use technologies and procedures, such as filters, that may terminate such unsolicited fax advertisements without delivering them.</li>
+    <li>We accept no responsibility for you being unable to correctly deliver outbound faxes due to any incompatibility, fault or incorrect configuration of our hardware, software or communication services.</li>
+    </ul>
+      </p>
       <h4>Accessing the Services and Account Security</h4>
       <p>
 	We reserve the right to withdraw or change the Services, in our sole discretion without notice. We will not be liable if for any reason all or any part of the Services is unavailable at any time or for any period. From time to time, we may restrict access to some or all parts of the Services.
       </p>
       <p>
 	We may require that you provide us certain information about you, such as your name, street address and email address, to use the Services or create an account with us. You must provide accurate and complete information to register for an account. You may not share your account credentials or make your account available to anyone else and are responsible for all activities that occur under your account. If you create an account or use the Services on behalf of another person or entity, you must have the authority to accept these Terms on their behalf. You agree that all information you provide through the Services is governed by our <a href="{% absolute_url 'privacy_policy' %}">Privacy Policy</a>, and you consent to all actions we take with respect to your information consistent with our <a href="{% absolute_url 'privacy_policy' %}">Privacy Policy</a>.
-When you use the Services, information related to you, which may include your sensitive and other personal information, may be generated and stored on your electronic devices.  It is your responsibility to manage the security of and access to your devices, and all data stored on your devices (including, for example, deleting temporary documents and information and clearing web browser cache and storage).     
+When you use the Services, information related to you, which may include your sensitive and other personal information, may be generated and stored on your electronic devices.  It is your responsibility to manage the security of and access to your devices, and all data stored on your devices (including, for example, deleting temporary documents and information and clearing web browser cache and storage).
       </p>
       <h4>Content</h4>
       <p>


### PR DESCRIPTION
Added section to TOS to:

1. Absolve Totally Legit Co of liability for unsent faxes
2. Clearly state customer responsibility to use correct destination fax numbers and to not use FHI's fax service for ulterior purposes (e.g. spam).