### PR TITLE
Make the fax logic less likely to timeout for initial assembly

### DIFF
--- a/fighthealthinsurance/common_view_logic.py
+++ b/fighthealthinsurance/common_view_logic.py
@@ -192,7 +192,7 @@ class SendFaxHelper:
             x for x in map(pmt.article_as_pdf, pubmed_docs) if x is not None
         ]
         files_for_fax.extend(pubmed_docs_paths)
-        doc_path = flexible_fax_magic.assemble_single_output(
+        doc_path = async_to_sync(flexible_fax_magic.assemble_single_output)(
             input_paths=files_for_fax, extra="", user_header=str(uuid.uuid4())
         )
         doc_fname = os.path.basename(doc_path)

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -250,7 +250,7 @@ class ChooseAppeal(View):
             )
             # Add the possible articles for inclusion
             if candidate_articles is not None:
-                for article in candidate_articles:
+                for article in candidate_articles[0:6]:
                     article_id = article.pmid
                     title = article.title
                     link = f"http://www.ncbi.nlm.nih.gov/pubmed/{article_id}"

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -7,7 +7,7 @@ FROM base-${TARGETARCH}
 ARG DEBIAN_FRONTEND=noninteractive
 
 # install all of the tools we need.
-RUN apt-get update && apt-get upgrade -y && apt-get install nginx vim emacs libmariadb-dev-compat default-libmysqlclient-dev libssl-dev nodejs npm python3-opencv libgl1 tesseract-ocr nano nfs-common sudo iputils-ping hylafax-client pandoc texlive texlive-luatex -y
+RUN apt-get update && apt-get upgrade -y && apt-get install nginx vim emacs libmariadb-dev-compat default-libmysqlclient-dev libssl-dev nodejs npm python3-opencv libgl1 tesseract-ocr nano nfs-common sudo iputils-ping hylafax-client pandoc texlive texlive-luatex texlive-latex-extra texlive-xelatex -y
 COPY /conf/nginx.default /etc/nginx/sites-available/default
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -7,7 +7,7 @@ FROM base-${TARGETARCH}
 ARG DEBIAN_FRONTEND=noninteractive
 
 # install all of the tools we need.
-RUN apt-get update && apt-get upgrade -y && apt-get install nginx vim emacs libmariadb-dev-compat default-libmysqlclient-dev libssl-dev nodejs npm python3-opencv libgl1 tesseract-ocr nano nfs-common sudo iputils-ping hylafax-client pandoc texlive texlive-luatex texlive-latex-extra texlive-xelatex -y
+RUN apt-get update && apt-get upgrade -y && apt-get install nginx vim emacs libmariadb-dev-compat default-libmysqlclient-dev libssl-dev nodejs npm python3-opencv libgl1 tesseract-ocr nano nfs-common sudo iputils-ping hylafax-client pandoc texlive texlive-luatex texlive-latex-extra texlive-xetex -y
 COPY /conf/nginx.default /etc/nginx/sites-available/default
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log


### PR DESCRIPTION
pandoc is can be slow and then we timeout (bad)
Make the conversions async & also only select ~6 studies (for now) we can improve this later (when we've got better ranking)