### PR TITLE
Clean up imports & guards

### DIFF
--- a/fighthealthinsurance/urls.py
+++ b/fighthealthinsurance/urls.py
@@ -38,7 +38,6 @@ urlpatterns = [
     # Internal-ish-views
     path("ziggy/rest/", include(rest_urls)),
     path("timbit/admin/", admin.site.urls),
-    path("error", views.ErrorView.as_view()),
     path("", include("django_prometheus.urls")),
     path("timbit/help/followup_sched", ScheduleFollowUps.as_view()),
     path(
@@ -49,7 +48,6 @@ urlpatterns = [
         "timbit/help/followup_fax_test",
         staff_member_required(fax_views.FollowUpFaxSenderView.as_view()),
     ),
-    path("error", views.ErrorView.as_view()),
     # These are links we e-mail people so might have some extra junk.
     # So if there's an extra / or . at the end we ignore it.
     path(

--- a/fighthealthinsurance/views.py
+++ b/fighthealthinsurance/views.py
@@ -1,37 +1,47 @@
 import json
-from typing import *
+import stripe
+import typing
 
+from PIL import Image
+from django import forms
 from django.conf import settings
 from django.shortcuts import redirect, render
 from django.urls import reverse
-from django.views import View, generic
 from django.utils.safestring import mark_safe
+from django.views import View, generic
 
-import stripe
-from fighthealthinsurance.common_view_logic import *
-from fighthealthinsurance.core_forms import *
-from fighthealthinsurance.generate_appeal import *
-from fighthealthinsurance.models import *
-from fighthealthinsurance.question_forms import *
-from fighthealthinsurance.utils import *
+from fighthealthinsurance import common_view_logic
+from fighthealthinsurance import core_forms
+from fighthealthinsurance import generate_appeal
+from fighthealthinsurance import models
+from fighthealthinsurance import question_forms
+from fighthealthinsurance import utils
 
-appealGenerator = AppealGenerator()
+appealGenerator = generate_appeal.AppealGenerator()
+
+
+def render_ocr_error(request, text):
+    return render(request, "server_side_ocr_error.html", context={
+        "error": text,
+    })
 
 
 class FollowUpView(generic.FormView):
     template_name = "followup.html"
-    form_class = FollowUpForm
+    form_class = core_forms.FollowUpForm
 
     def get_initial(self):
         # Set the initial arguments to the form based on the URL route params.
         # Also make sure we can resolve the denial
-        denial = FollowUpHelper.fetch_denial(**self.kwargs)
+        #
+        # NOTE: Potential security issue here
+        denial = common_view_logic.FollowUpHelper.fetch_denial(**self.kwargs)
         if denial is None:
             raise Exception(f"Could not find denial for {self.kwargs}")
         return self.kwargs
 
     def form_valid(self, form):
-        FollowUpHelper.store_follow_up_result(**form.cleaned_data)
+        common_view_logic.FollowUpHelper.store_follow_up_result(**form.cleaned_data)
         return render(self.request, "followup_thankyou.html")
 
 
@@ -41,40 +51,43 @@ class ProVersionThankYouView(generic.TemplateView):
 
 class ProVersionView(generic.FormView):
     template_name = "professional.html"
-    form_class = InterestedProfessionalForm
+    form_class = core_forms.InterestedProfessionalForm
 
     def form_valid(self, form):
         form.save()
-        if (
+
+        if not (
             "clicked_for_paid" in form.cleaned_data
             and form.cleaned_data["clicked_for_paid"]
         ):
-            stripe.api_key = settings.STRIPE_API_SECRET_KEY
-            stripe.publishable_key = settings.STRIPE_API_PUBLISHABLE_KEY
-            product = stripe.Product.create(name="Pre-Signup")
-            product_price = stripe.Price.create(
-                unit_amount=1000, currency="usd", product=product["id"]
-            )
-            items = [
-                {
-                    "price": product_price["id"],
-                    "quantity": 1,
-                }
-            ]
-            checkout = stripe.checkout.Session.create(
-                line_items=items,
-                mode="payment",  # No subscriptions
-                success_url=self.request.build_absolute_uri(
-                    reverse("pro_version_thankyou")
-                ),
-                cancel_url=self.request.build_absolute_uri(
-                    reverse("pro_version_thankyou")
-                ),
-                customer_email=form.cleaned_data["email"],
-            )
-            checkout_url = checkout.url
-            return redirect(checkout_url)
-        return render(self.request, "professional_thankyou.html")
+            return render(self.request, "professional_thankyou.html")
+
+        stripe.api_key = settings.STRIPE_API_SECRET_KEY
+        stripe.publishable_key = settings.STRIPE_API_PUBLISHABLE_KEY
+
+        product = stripe.Product.create(name="Pre-Signup")
+        product_price = stripe.Price.create(
+            unit_amount=1000, currency="usd", product=product["id"]
+        )
+        items = [
+            {
+                "price": product_price["id"],
+                "quantity": 1,
+            }
+        ]
+        checkout = stripe.checkout.Session.create(
+            line_items=items,
+            mode="payment",  # No subscriptions
+            success_url=self.request.build_absolute_uri(
+                reverse("pro_version_thankyou")
+            ),
+            cancel_url=self.request.build_absolute_uri(
+                reverse("pro_version_thankyou")
+            ),
+            customer_email=form.cleaned_data["email"],
+        )
+        checkout_url = checkout.url
+        return redirect(checkout_url)
 
 
 class IndexView(generic.TemplateView):
@@ -117,11 +130,6 @@ class ContactView(generic.TemplateView):
         return {"title": "Contact Us"}
 
 
-class ErrorView(View):
-    def get(self, request):
-        raise Exception("test")
-
-
 class ShareDenialView(View):
     def get(self, request):
         return render(request, "share_denial.html", context={"title": "Share Denial"})
@@ -132,13 +140,13 @@ class ShareAppealView(View):
         return render(request, "share_appeal.html", context={"title": "Share Appeal"})
 
     def post(self, request):
-        form = ShareAppealForm(request.POST)
+        form = core_forms.ShareAppealForm(request.POST)
         if form.is_valid():
             denial_id = form.cleaned_data["denial_id"]
-            hashed_email = Denial.get_hashed_email(form.cleaned_data["email"])
+            hashed_email = models.Denial.get_hashed_email(form.cleaned_data["email"])
 
             # Update the denial
-            denial = Denial.objects.filter(
+            denial = models.Denial.objects.filter(
                 denial_id=denial_id,
                 # Include the hashed e-mail so folks can't brute force denial_id
                 hashed_email=hashed_email,
@@ -146,7 +154,7 @@ class ShareAppealView(View):
             print(form.cleaned_data)
             denial.appeal_text = form.cleaned_data["appeal_text"]
             denial.save()
-            pa = ProposedAppeal(
+            pa = models.ProposedAppeal(
                 appeal_text=form.cleaned_data["appeal_text"],
                 for_denial=denial,
                 chosen=True,
@@ -163,31 +171,28 @@ class RemoveDataView(View):
             "remove_data.html",
             context={
                 "title": "Remove My Data",
-                "form": DeleteDataForm(),
+                "form": core_forms.DeleteDataForm(),
             },
         )
 
     def post(self, request):
-        form = DeleteDataForm(request.POST)
+        form = core_forms.DeleteDataForm(request.POST)
+
         if form.is_valid():
             email = form.cleaned_data["email"]
-            RemoveDataHelper.remove_data_for_email(email)
-            return render(
-                request,
-                "removed_data.html",
-                context={
-                    "title": "Remove My Data",
-                },
-            )
-        else:
-            return render(
-                request,
-                "remove_data.html",
-                context={
-                    "title": "Remove My Data",
-                    "form": form,
-                },
-            )
+            common_view_logic.RemoveDataHelper.remove_data_for_email(email)
+            return render(request, "removed_data.html", context={
+                "title": "Remove My Data",
+            })
+
+        return render(
+            request,
+            "remove_data.html",
+            context={
+                "title": "Remove My Data",
+                "form": form,
+            },
+        )
 
 
 class RecommendAppeal(View):
@@ -197,107 +202,111 @@ class RecommendAppeal(View):
 
 class FindNextSteps(View):
     def post(self, request):
-        form = PostInferedForm(request.POST)
+        form = core_forms.PostInferedForm(request.POST)
         if form.is_valid():
             denial_id = form.cleaned_data["denial_id"]
             email = form.cleaned_data["email"]
 
-            next_step_info = FindNextStepsHelper.find_next_steps(**form.cleaned_data)
-            denial_ref_form = DenialRefForm(
+            next_step_info = common_view_logic.FindNextStepsHelper.find_next_steps(
+                **form.cleaned_data
+            )
+            denial_ref_form = core_forms.DenialRefForm(
                 initial={
                     "denial_id": denial_id,
                     "email": email,
                     "semi_sekret": next_step_info.semi_sekret,
                 }
             )
-            return render(
-                request,
-                "outside_help.html",
-                context={
-                    "outside_help_details": next_step_info.outside_help_details,
-                    "combined": next_step_info.combined_form,
-                    "denial_form": denial_ref_form,
-                },
-            )
-        else:
-            # If not valid take the user back.
-            return render(
-                request,
-                "categorize.html",
-                context={
-                    "post_infered_form": form,
-                    "upload_more": True,
-                },
-            )
+            return render(request, "outside_help.html", context={
+                "outside_help_details": next_step_info.outside_help_details,
+                "combined": next_step_info.combined_form,
+                "denial_form": denial_ref_form,
+            })
+
+        # If not valid take the user back.
+        return render(
+            request,
+            "categorize.html",
+            context={
+                "post_infered_form": form,
+                "upload_more": True,
+            },
+        )
 
 
 class ChooseAppeal(View):
     def post(self, request):
-        form = ChooseAppealForm(request.POST)
-        if form.is_valid():
-            appeal_info_extracted = ""
-            (appeal_fax_number, insurance_company, candidate_articles) = (
-                ChooseAppealHelper.choose_appeal(**form.cleaned_data)
-            )
-            fax_form = FaxForm(
-                initial={
-                    "denial_id": form.cleaned_data["denial_id"],
-                    "email": form.cleaned_data["email"],
-                    "semi_sekret": form.cleaned_data["semi_sekret"],
-                    "fax_phone": appeal_fax_number,
-                    "insurance_company": insurance_company,
-                }
-            )
-            # Add the possible articles for inclusion
-            if candidate_articles is not None:
-                for article in candidate_articles[0:6]:
-                    article_id = article.pmid
-                    title = article.title
-                    link = f"http://www.ncbi.nlm.nih.gov/pubmed/{article_id}"
-                    label = mark_safe(
-                        f"Include Summary* of PubMed Article <a href='{link}'>{title} -- {article_id}</a>"
-                    )
-                    fax_form.fields["pubmed_" + article_id] = forms.BooleanField(
-                        label=label, required=False, initial=True
-                    )
+        form = core_forms.ChooseAppealForm(request.POST)
 
-            return render(
-                request,
-                "appeal.html",
-                context={
-                    "appeal": form.cleaned_data["appeal_text"],
-                    "user_email": form.cleaned_data["email"],
-                    "denial_id": form.cleaned_data["denial_id"],
-                    "appeal_info_extract": appeal_info_extracted,
-                    "fax_form": fax_form,
-                },
-            )
-        else:
+        if not form.is_valid():
             print(form)
+            return
+
+        (
+            appeal_fax_number,
+            insurance_company,
+            candidate_articles,
+        ) = common_view_logic.ChooseAppealHelper.choose_appeal(
+            **form.cleaned_data
+        )
+
+        appeal_info_extracted = ""
+        fax_form = core_forms.FaxForm(
+            initial={
+                "denial_id": form.cleaned_data["denial_id"],
+                "email": form.cleaned_data["email"],
+                "semi_sekret": form.cleaned_data["semi_sekret"],
+                "fax_phone": appeal_fax_number,
+                "insurance_company": insurance_company,
+            }
+        )
+        # Add the possible articles for inclusion
+        if candidate_articles is not None:
+            for article in candidate_articles[0:6]:
+                article_id = article.pmid
+                title = article.title
+                link = f"http://www.ncbi.nlm.nih.gov/pubmed/{article_id}"
+                label = mark_safe(
+                    f"Include Summary* of PubMed Article "
+                    f"<a href='{link}'>{title} -- {article_id}</a>"
+                )
+                fax_form.fields["pubmed_" + article_id] = forms.BooleanField(
+                    label=label,
+                    required=False,
+                    initial=True,
+                )
+
+        return render(request, "appeal.html", context={
+            "appeal": form.cleaned_data["appeal_text"],
+            "user_email": form.cleaned_data["email"],
+            "denial_id": form.cleaned_data["denial_id"],
+            "appeal_info_extract": appeal_info_extracted,
+            "fax_form": fax_form,
+        })
 
 
 class GenerateAppeal(View):
     def post(self, request):
-        form = DenialRefForm(request.POST)
-        if form.is_valid():
-            # We copy _most_ of the input over for the form context
-            elems = dict(request.POST)
-            # Query dict is of lists
-            elems = dict((k, v[0]) for k, v in elems.items())
-            del elems["csrfmiddlewaretoken"]
-            return render(
-                request,
-                "appeals.html",
-                context={
-                    "form_context": json.dumps(elems),
-                    "user_email": form.cleaned_data["email"],
-                    "denial_id": form.cleaned_data["denial_id"],
-                    "semi_sekret": form.cleaned_data["semi_sekret"],
-                },
-            )
-        else:
+        form = core_forms.DenialRefForm(request.POST)
+        if not form.is_valid():
             # TODO: Send user back to fix the form.
-            pass
+            return
+
+        # We copy _most_ of the input over for the form context
+        elems = dict(request.POST)
+        # Query dict is of lists
+        elems = dict((k, v[0]) for k, v in elems.items())
+        del elems["csrfmiddlewaretoken"]
+        return render(
+            request,
+            "appeals.html",
+            context={
+                "form_context": json.dumps(elems),
+                "user_email": form.cleaned_data["email"],
+                "denial_id": form.cleaned_data["denial_id"],
+                "semi_sekret": form.cleaned_data["semi_sekret"],
+            },
+        )
 
 
 class StreamingEntityBackend(View):
@@ -306,9 +315,9 @@ class StreamingEntityBackend(View):
     async def post(self, request):
         print(request)
         print(request.POST)
-        form = DenialRefForm(request.POST)
+        form = core_forms.DenialRefForm(request.POST)
         if form.is_valid():
-            return await DenialCreatorHelper.extract_entity(
+            return await common_view_logic.DenialCreatorHelper.extract_entity(
                 form.cleaned_data["denial_id"])
         else:
             print(f"Error processing {form}")
@@ -320,18 +329,23 @@ class AppealsBackend(View):
     async def post(self, request):
         print(request)
         print(request.POST)
-        form = DenialRefForm(request.POST)
-        if form.is_valid():
-            return await AppealsBackendHelper.generate_appeals(request.POST)
-        else:
+        form = core_forms.DenialRefForm(request.POST)
+        if not form.is_valid():
             print(f"Error processing {form}")
+            return
+
+        return await common_view_logic.AppealsBackendHelper.generate_appeals(request.POST)
 
     async def get(self, request):
-        form = DenialRefForm(request.GET)
-        if form.is_valid():
-            return await AppealsBackendHelper.generate_appeals(request.GET)
-        else:
+        form = core_forms.DenialRefForm(request.GET)
+
+        if not form.is_valid():
             print(f"Error processing {form}")
+            return
+
+        return await common_view_logic.AppealsBackendHelper.generate_appeals(
+            request.GET,
+        )
 
 
 class OCRView(View):
@@ -339,7 +353,6 @@ class OCRView(View):
         # Load easy ocr reader if possible
         try:
             import easyocr
-
             self._easy_ocr_reader = easyocr.Reader(["en"], gpu=False)
         except Exception:
             pass
@@ -353,29 +366,21 @@ class OCRView(View):
             files = dict(request.FILES.lists())
             uploader = files["uploader"]
             doc_txt = self._ocr(uploader)
-            return render(
-                request,
-                "scrub.html",
-                context={"ocr_result": doc_txt, "upload_more": False},
-            )
+            return render(request, "scrub.html", context={
+                "ocr_result": doc_txt,
+                "upload_more": False,
+            })
+
         except AttributeError:
-            error_txt = "Unsupported file"
-            return render(
-                request, "server_side_ocr_error.html", context={"error": error_txt}
-            )
+            render_ocr_error(request, "Unsupported file")
+
         except KeyError:
-            error_txt = "Missing file"
-            return render(
-                request, "server_side_ocr_error.html", context={"error": error_txt}
-            )
+            return render_ocr_error(request, "Missing file")
 
     def _ocr(self, uploader):
-        from PIL import Image
-
         def ocr_upload(x):
             try:
                 import pytesseract
-
                 img = Image.open(x)
                 return pytesseract.image_to_string(img)
             except Exception:
@@ -388,9 +393,9 @@ class OCRView(View):
 
 class InitialProcessView(generic.FormView):
     template_name = "scrub.html"
-    form_class = DenialForm
+    form_class = core_forms.DenialForm
 
-    def get_ocr_result(self) -> Optional[str]:
+    def get_ocr_result(self) -> typing.Optional[str]:
         if self.request.method == "POST":
             return self.request.POST.get("denial_text", None)
         return None
@@ -402,108 +407,106 @@ class InitialProcessView(generic.FormView):
         return context
 
     def form_valid(self, form):
-        denial_response = DenialCreatorHelper.create_denial(**form.cleaned_data)
-        form = HealthHistory(
-            initial={
-                "denial_id": denial_response.denial_id,
-                "email": form.cleaned_data["email"],
-                "semi_sekret": denial_response.semi_sekret,
-            }
+        denial_response = common_view_logic.DenialCreatorHelper.create_denial(
+            **form.cleaned_data,
         )
+
+        form = core_forms.HealthHistory(initial={
+            "denial_id": denial_response.denial_id,
+            "email": form.cleaned_data["email"],
+            "semi_sekret": denial_response.semi_sekret,
+        })
+
         # TODO: This should be a redirect to a new view to prevent
         # double-submission and other potentially unexpected issues. Normally,
         # this can be done by assigning a success_url to the view and Django
         # will take care of the rest. Since we need to pass extra information
         # along, we can use get_success_url to generate a querystring.
-        return render(
-            self.request,
-            "health_history.html",
-            context={
-                "form": form,
-                "next": reverse("hh"),
-            },
-        )
+        return render(self.request, "health_history.html", context={
+            "form": form,
+            "next": reverse("hh"),
+        })
 
 
 class EntityExtractView(generic.FormView):
-    form_class = EntityExtractForm
+    form_class = core_forms.EntityExtractForm
     template_name = "entity_extract.html"
 
     def form_valid(self, form):
-        denial_response = DenialCreatorHelper.update_denial(**form.cleaned_data)
-        form = PostInferedForm(
-            initial={
-                "denial_type": denial_response.selected_denial_type,
-                "denial_id": denial_response.denial_id,
-                "email": form.cleaned_data["email"],
-                "your_state": denial_response.your_state,
-                "procedure": denial_response.procedure,
-                "diagnosis": denial_response.diagnosis,
-                "semi_sekret": denial_response.semi_sekret,
-            }
+        denial_response = common_view_logic.DenialCreatorHelper.update_denial(
+            **form.cleaned_data,
         )
+
+        form = core_forms.PostInferedForm(initial={
+            "denial_type": denial_response.selected_denial_type,
+            "denial_id": denial_response.denial_id,
+            "email": form.cleaned_data["email"],
+            "your_state": denial_response.your_state,
+            "procedure": denial_response.procedure,
+            "diagnosis": denial_response.diagnosis,
+            "semi_sekret": denial_response.semi_sekret,
+        })
 
         # TODO: This should be a redirect to a new view to prevent
         # double-submission and other potentially unexpected issues. Normally,
         # this can be done by assigning a success_url to the view and Django
         # will take care of the rest. Since we need to pass extra information
         # along, we can use get_success_url to generate a querystring.
-        return render(
-            self.request,
-            "categorize.html",
-            context={
-                "post_infered_form": form,
-                "upload_more": True,
-            },
-        )
+        return render(self.request, "categorize.html", context={
+            "post_infered_form": form,
+            "upload_more": True,
+        })
 
 
 class PlanDocumentsView(generic.FormView):
-    form_class = HealthHistory
+    form_class = core_forms.HealthHistory
     template_name = "health_history.html"
 
     def form_valid(self, form):
-        denial_response = DenialCreatorHelper.update_denial(**form.cleaned_data)
-        form = PlanDocumentsForm(
+        denial_response = common_view_logic.DenialCreatorHelper.update_denial(
+            **form.cleaned_data,
+        )
+
+        form = core_forms.PlanDocumentsForm(
             initial={
                 "denial_id": denial_response.denial_id,
                 "email": form.cleaned_data["email"],
                 "semi_sekret": denial_response.semi_sekret,
             }
         )
+
         # TODO: This should be a redirect to a new view to prevent
         # double-submission and other potentially unexpected issues. Normally,
         # this can be done by assigning a success_url to the view and Django
         # will take care of the rest. Since we need to pass extra information
         # along, we can use get_success_url to generate a querystring.
-        return render(
-            self.request,
-            "plan_documents.html",
-            context={
-                "form": form,
-                "next": reverse("dvc"),
-            },
-        )
+        return render(self.request, "plan_documents.html", context={
+            "form": form,
+            "next": reverse("dvc"),
+        })
 
 
 class DenialCollectedView(generic.FormView):
-    form_class = PlanDocumentsForm
+    form_class = core_forms.PlanDocumentsForm
     template_name = "plan_documents.html"
 
     def form_valid(self, form):
-        denial_response = DenialCreatorHelper.update_denial(**form.cleaned_data)
+        # TODO: Make use of the response from this
+        common_view_logic.DenialCreatorHelper.update_denial(**form.cleaned_data)
+
         # TODO: This should be a redirect to a new view to prevent
         # double-submission and other potentially unexpected issues. Normally,
         # this can be done by assigning a success_url to the view and Django
         # will take care of the rest. Since we need to pass extra information
         # along, we can use get_success_url to generate a querystring.
-        new_form = EntityExtractForm(
+        new_form = core_forms.EntityExtractForm(
             initial={
                 "denial_id": form.cleaned_data["denial_id"],
                 "email": form.cleaned_data["email"],
                 "semi_sekret": form.cleaned_data["semi_sekret"],
             }
         )
+
         return render(
             self.request,
             "entity_extract.html",


### PR DESCRIPTION
The goal of this is to clean up imports to be more direct instead of using `import *` and fixes some cases where a lot of code was in a conditional to use a guard instead.

Added some **TODO** blocks in cases where it seemed important.